### PR TITLE
Replace chairing/election section with solid-inspired chair election process

### DIFF
--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -255,36 +255,121 @@
       or discriminate against any group participant or their employer.
     </p>
     <h2 id="chairs">
-      Chair Selection
+      Chairs
     </h2>
     <p>
-      Participants in this group choose their Chair(s) and can replace their
-      Chair(s) at any time using whatever means they prefer. However, if 5
-      participants, no two from the same organisation, call for an election,
-      the group must use the following process to replace any current Chair(s)
-      with a new Chair, consulting the Community Development Lead on election
-      operations (e.g., voting infrastructure and using <a href=
-      "https://tools.ietf.org/html/rfc2777">RFC 2777</a>).
+      The <a href="https://www.w3.org/Guide/chair/role.html">role of the Chair is described in the <a href="https://www.w3.org/Guide/">Art of Consensus</a>.
     </p>
-    <ol>
-      <li>Participants announce their candidacies. Participants have 14 days to
-      announce their candidacies, but this period ends as soon as all
-      participants have announced their intentions. If there is only one
-      candidate, that person becomes the Chair. If there are two or more
-      candidates, there is a vote. Otherwise, nothing changes.
-      </li>
-      <li>Participants vote. Participants have 21 days to vote for a single
-      candidate, but this period ends as soon as all participants have voted.
-      The individual who receives the most votes, no two from the same
-      organisation, is elected chair. In case of a tie, RFC2777 is used to
-      break the tie. An elected Chair may appoint co-Chairs.
-      </li>
-    </ol>
     <p>
-      Participants dissatisfied with the outcome of an election may ask the
-      Community Development Lead to intervene. The Community Development Lead,
-      after evaluating the election, may take any action including no action.
+      The Community Group participants appoints (and re-appoints) Chairs for the group.
     </p>
+    <p>
+      The chair and the W3C Team Contact of the group SHOULD NOT be the same individual.
+    </p>
+    <p>
+      Participation as Chair afforded to the specific individuals elected or appointed to those positions, and a participant’s seat MUST NOT be delegated to any other person.
+    </p>
+    <p>
+      For most Chair nominees, the primary affiliation is their employer and will match their affiliation in the W3C database. For contractors and independents, this will normally be their contracting company or their independent status; in some cases (e.g. where a consultant is consulting for only one organization) this may be the organization for whom the nominee is consulting.
+    </p>
+    <p>
+      Chair nominees and elected chairs per term MUST have unique affiliations.
+    </p>
+    <p>
+      An affiliation MAY submit one ballot that ranks candidates in their preferred order.
+    </p>
+    <h2 id="choosing-chairs">
+      Choosing Chairs
+    </h2>
+    <ul>
+      <li>
+
+      </li>
+      <li>
+        At any given time there may be up to three co-chairs, each holding one seat.
+        Each seat defines a 2 year cycle of service.
+      </li>
+      <li>
+        In the first election after ratification of this charter, all seats will be up for election.
+        Thereafter, in each year, a single election will be held to fill any vacant seats.
+      </li>
+      <li>
+        In the case of interim vacancy, the remaining chairs may appoint a co-chair for each open seat, hold an election for the same, or wait until the next election, at their discretion.
+        If the chairs do not take any action, the seat will automatically be up for election in any cycle.
+        Any such interim appointments or elections shall hold the seat until the end of its natural cycle.
+      </li>
+      <li>
+        Reelection is restricted to two consecutive terms, with the possibility of being reelected after sitting out one election cycle.
+      </li>
+      <li>
+        In an election year, current chairs will select a date for elections, which will set a nomination period of two weeks, starting 4 weeks prior to the election.
+      </li>
+      <li>
+        For an individual to run for election, they must self-nominate and make a statement regarding their background and why they are running, on the group mailing list.
+      </li>
+      <li>
+        The current chairs will host a conference call during the nomination period, during which candidates may make a statement and answer questions from the community.
+      </li>
+      <li>
+        If, at the end of nominations, any given seat only has a single candidate, that candidate immediately wins that seat.
+        For any seats with multiple nominees, there will be an election for those seats.
+      </li>
+      <li>
+        If, after nominations, any given seat has no candidates, the remaining chairs after any election (if necessary for other seats), will address the vacancy as an interim vacancy, described above.
+      </li>
+      <li>
+        To elect one of multiple candidates, a vote will be held by the election mechanism of ranked choice voting, in which voters rank candidates by preference on their ballots.
+        The candidate with the majority (more than 50%) of first-choice votes wins outright.
+        If no candidate gets a majority of first-choice votes, the candidate who ranked the worst is eliminated, and that candidate’s voters’ ballots are redistributed to their second-choice pick.
+        If the vote results in a tie, an immediate runoff of the top two candidates shall be held.
+        If the vote remains tied, the winner shall be the candidate whose nomination was first recorded publicly on the group email list.
+      </li>
+    </ul>
+    <h2 id="offboarding-chairs">
+      Offboarding Chairs
+    </h2>
+    <ul>
+      </li>
+      <li>
+        Chairs may be removed from their duties through a no-confidence vote.
+      </li>
+      <li>          
+        If a participant of the community group wishes to call for the recall of a chair–for any reason–that participant must first privately communicate with the other chairs their desire and reason for doing so.
+        Those chairs must give the participant an opportunity to discuss their concerns with a goal of resolving them.
+        If, after 30 days, the participant feels their issues are not addressed, they may then escalate to a public call for a no confidence vote.
+        If after 60 days, the participant has not made that call for a no confidence vote, the matter is dropped; any further attempts to remove the chair in question must begin with a new round of private communication.
+      </li>
+      <li>
+        A public call for no confidence must be announced to the group email list stating the name of the chair subject to the recall and the names and emails of at least 3 participants of the group who thereby call for a recall.
+        This announcement must come from the participant who initiated the private communication with the chairs to discuss their concerns. The other two supporting participants MUST reply to that email on the public list within 48 hours to confirm their support for a no-confidence vote of the chair in question.
+      </li>
+      <li>
+        The other chairs must acknowledge the call for no confidence within 7 days of all three participants declaring their support.
+      </li>
+      <li>
+        Within 30 days of a call for no confidence, the other chairs must hold a conference call at which the parties seeking no confidence will have an opportunity to present their case and participants of the group will be able to ask clarifying questions.
+        The chair in question shall not moderate this call.
+        They will, however, have equal time to respond during that same call to the case made against them.
+      </li>
+      <li>
+        During the week following this conference call, participants may cast votes in favor or against the recall by posting to the email list.
+      </li>
+      <li>
+        If affirmative votes cast that week (in favor of recall) comprise greater than two-thirds of the total votes cast, then the chair in question is removed and the seat shall be treated as an interim vacancy.
+      </li>
+      <li>
+        Participants are not required to vote.
+        Abstentions may be recorded; such abstentions shall not count towards the total number of votes when calculating the two-thirds majority.
+      </li>
+      <li>          
+        A Chair who has been removed may stand for re-election.
+      </li>
+      <li>
+        Only one call for no-confidence, for one chair, may be in process at any given time.
+        Priority shall be given to the first such vote to be publicly called.
+        Any subsequent public calls must wait until any previous recalls are resolved, then must start with private communication as described above.
+      </li>
+    </ul>
     <h2 id="charter-change">
       Amendments to this Charter
     </h2>

--- a/CGCharter-1727386911.html
+++ b/CGCharter-1727386911.html
@@ -261,115 +261,102 @@
       The <a href="https://www.w3.org/Guide/chair/role.html">role of the Chair is described in the <a href="https://www.w3.org/Guide/">Art of Consensus</a>.
     </p>
     <p>
-      The Community Group participants appoints (and re-appoints) Chairs for the group.
+      The Community Group participants appoint (and re-appoint) no less than One (1) and no more than Three (3) Chairs for the group at any given time.
+      The W3C Team Contact of the group SHOULD NOT be one of the chairs at any point.
+      Participation as Chair is afforded to the specific individuals elected to those positions, and a participant&quot;s seat MUST NOT be delegated to any other person.
     </p>
-    <p>
-      The chair and the W3C Team Contact of the group SHOULD NOT be the same individual.
-    </p>
-    <p>
-      Participation as Chair afforded to the specific individuals elected or appointed to those positions, and a participant’s seat MUST NOT be delegated to any other person.
-    </p>
-    <p>
-      For most Chair nominees, the primary affiliation is their employer and will match their affiliation in the W3C database. For contractors and independents, this will normally be their contracting company or their independent status; in some cases (e.g. where a consultant is consulting for only one organization) this may be the organization for whom the nominee is consulting.
-    </p>
-    <p>
-      Chair nominees and elected chairs per term MUST have unique affiliations.
-    </p>
-    <p>
+    <p>      
+      For most Chair nominees, the primary affiliation is their employer and will match their affiliation in the W3C database.
+      For contractors and independents, this will normally be their contracting company or their independent status;
+      in some cases (e.g. where a consultant is consulting for only one organization) this may be the organization for whom the nominee is consulting.
+      <strong>Chair nominees, elected chairs, and appointed chairs MUST have unique affiliations publicly stated at time of nomination, election (if it has changed since last disclosure), or appointment.</strong>
+      Publicly stating additional or secondary affiliations is not required but recommended.
       An affiliation MAY submit one ballot that ranks candidates in their preferred order.
     </p>
-    <h2 id="choosing-chairs">
-      Choosing Chairs
+    <h2 id="chairs">
+    Chair Selection
     </h2>
     <ul>
-      <li>
-
-      </li>
-      <li>
+        <li>
         At any given time there may be up to three co-chairs, each holding one seat.
         Each seat defines a 2 year cycle of service.
-      </li>
-      <li>
+        </li>
+        <li>
         In the first election after ratification of this charter, all seats will be up for election.
         Thereafter, in each year, a single election will be held to fill any vacant seats.
-      </li>
-      <li>
+        </li>
+        <li>
         In the case of interim vacancy, the remaining chairs may appoint a co-chair for each open seat, hold an election for the same, or wait until the next election, at their discretion.
-        If the chairs do not take any action, the seat will automatically be up for election in any cycle.
+        If the chairs do not take any action, the seat will automatically be up for election in the next cycle.
         Any such interim appointments or elections shall hold the seat until the end of its natural cycle.
-      </li>
-      <li>
+        </li>
+        <li>
         Reelection is restricted to two consecutive terms, with the possibility of being reelected after sitting out one election cycle.
-      </li>
-      <li>
+        </li>
+        <li>
         In an election year, current chairs will select a date for elections, which will set a nomination period of two weeks, starting 4 weeks prior to the election.
-      </li>
-      <li>
+        </li>
+        <li>
         For an individual to run for election, they must self-nominate and make a statement regarding their background and why they are running, on the group mailing list.
-      </li>
-      <li>
+        </li>
+        <li>
         The current chairs will host a conference call during the nomination period, during which candidates may make a statement and answer questions from the community.
-      </li>
-      <li>
+        </li>
+        <li>
         If, at the end of nominations, any given seat only has a single candidate, that candidate immediately wins that seat.
         For any seats with multiple nominees, there will be an election for those seats.
-      </li>
-      <li>
+        </li>
+        <li>
         If, after nominations, any given seat has no candidates, the remaining chairs after any election (if necessary for other seats), will address the vacancy as an interim vacancy, described above.
-      </li>
-      <li>
-        To elect one of multiple candidates, a vote will be held by the election mechanism of ranked choice voting, in which voters rank candidates by preference on their ballots.
-        The candidate with the majority (more than 50%) of first-choice votes wins outright.
-        If no candidate gets a majority of first-choice votes, the candidate who ranked the worst is eliminated, and that candidate’s voters’ ballots are redistributed to their second-choice pick.
-        If the vote results in a tie, an immediate runoff of the top two candidates shall be held.
-        If the vote remains tied, the winner shall be the candidate whose nomination was first recorded publicly on the group email list.
-      </li>
+        </li>
+        <li>
+        To elect one of multiple candidates, a vote will be held by the election mechanism of ranked choice voting, in which voters rank candidates by preference on their ballots. The candidate with the majority (more than 50%) of first-choice votes wins outright. If no candidate gets a majority of first-choice votes, the candidate who ranked the worst is eliminated, and that candidate&quot;s voters&quot; ballots are redistributed to their second-choice pick. If the vote results in a tie, an immediate runoff of the top two candidates shall be held. If the vote remains tied, the winner shall be the candidate whose nomination was first recorded publicly on the group email list.
     </ul>
-    <h2 id="offboarding-chairs">
-      Offboarding Chairs
+    <h2 id="chairs">
+    Chair Offboarding
     </h2>
     <ul>
-      </li>
-      <li>
-        Chairs may be removed from their duties through a no-confidence vote.
-      </li>
-      <li>          
-        If a participant of the community group wishes to call for the recall of a chair–for any reason–that participant must first privately communicate with the other chairs their desire and reason for doing so.
-        Those chairs must give the participant an opportunity to discuss their concerns with a goal of resolving them.
-        If, after 30 days, the participant feels their issues are not addressed, they may then escalate to a public call for a no confidence vote.
-        If after 60 days, the participant has not made that call for a no confidence vote, the matter is dropped; any further attempts to remove the chair in question must begin with a new round of private communication.
-      </li>
-      <li>
-        A public call for no confidence must be announced to the group email list stating the name of the chair subject to the recall and the names and emails of at least 3 participants of the group who thereby call for a recall.
-        This announcement must come from the participant who initiated the private communication with the chairs to discuss their concerns. The other two supporting participants MUST reply to that email on the public list within 48 hours to confirm their support for a no-confidence vote of the chair in question.
-      </li>
-      <li>
+        <li>
+        A chair may voluntarily off-board at any given time; this should be done publicly and on the mailing list.
+        </li>
+        <li>
+        Chairs may also be removed from their duties through a no-confidence vote.
+        </li>
+        <li>
+        If a participant of the community group wishes to call for the recall of a chair, for any reason, that participant must first privately communicate with one or more of the other chairs and/or W3C contact their desire and reason for doing so.
+        Those chairs must give the participant an opportunity to discuss their concerns with a goal of resolving them. If, after 30 days, the participant feels their issues have not been adequately addressed, they may then escalate to a public call for a no confidence vote (without having to disclose with whom they have been discussing the matter).
+        If, after 60 days, the participant has not made a call for a no confidence vote, the matter should be considered dropped; any further attempts to remove the chair in question must begin with a new round of private communication.
+        </li>
+        <li>
+        A public call for no confidence must be announced to the group email list stating the name of the chair subject to the recall.
+        This announcement must come from the participant who initiated the private communication with the chairs to discuss their concerns. 
+        At least two other supporting participants MUST reply to that email on the public list within 48 hours to confirm their support for a no-confidence vote of the chair in question.
+        </li>
+        <li>
         The other chairs must acknowledge the call for no confidence within 7 days of all three participants declaring their support.
-      </li>
-      <li>
-        Within 30 days of a call for no confidence, the other chairs must hold a conference call at which the parties seeking no confidence will have an opportunity to present their case and participants of the group will be able to ask clarifying questions.
-        The chair in question shall not moderate this call.
+        </li>
+        <li>
+        UNLESS the chair in which no-confidence has been expressed voluntarily offboards and opts out of the session on the mailing list, and within 30 days of a call for no confidence, the other chairs MUST hold a conference call at which the parties seeking no confidence will have an opportunity to present their case and participants of the group will be able to ask clarifying questions. 
+        The chair in question SHALL NOT moderate this call.
         They will, however, have equal time to respond during that same call to the case made against them.
-      </li>
-      <li>
+        </li>
+        <li>
         During the week following this conference call, participants may cast votes in favor or against the recall by posting to the email list.
-      </li>
-      <li>
         If affirmative votes cast that week (in favor of recall) comprise greater than two-thirds of the total votes cast, then the chair in question is removed and the seat shall be treated as an interim vacancy.
-      </li>
-      <li>
-        Participants are not required to vote.
+        </li>
+        <li>
+        Participants are not required to vote. 
         Abstentions may be recorded; such abstentions shall not count towards the total number of votes when calculating the two-thirds majority.
-      </li>
-      <li>          
+        </li>
+        <li>
         A Chair who has been removed may stand for re-election.
-      </li>
-      <li>
+        </li>
+        <li>
         Only one call for no-confidence, for one chair, may be in process at any given time.
-        Priority shall be given to the first such vote to be publicly called.
+        Priority shall be given to the first such vote to be publicly called. 
         Any subsequent public calls must wait until any previous recalls are resolved, then must start with private communication as described above.
-      </li>
-    </ul>
+        </li>
+    </ul> 
     <h2 id="charter-change">
       Amendments to this Charter
     </h2>


### PR DESCRIPTION
See second commit for a diff of everything I changed-- first diff is just reformating markdown as html.

The original can be found [here](https://github.com/solid/process/blob/39442109da934a1a305fcc047d7fa2f174dd0abd/solid-cg-charter.md?plain=1#L146) on the solid org.  Sorry for the messy commits, forgot to split into two commits and hacked it together in a hurry.